### PR TITLE
fix: non-numeric derived sensors failed to be added to Home Assistant

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD033": false,
   "MD060": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2026-08-19
+
+### Fixed
+
+- **`Dominant Pollutant` failed to start and errored on every update.** The sensor
+  reports which pollutant drives the European AQI, so its value is a name such as
+  `o3` — but it inherited `state_class: measurement` from its base class, which
+  tells Home Assistant to expect a number. Home Assistant rejected the state with
+  `ValueError: ... it has the non-numeric value`, the entity was never added, and
+  the error repeated on every air-quality and weather coordinator refresh. This
+  affected every installation that receives European sub-AQI data, in the default
+  configuration. The sensor now declares `device_class: enum`.
+- **`Lightning Risk` had the same defect.** It returns `none`/`low`/`medium`/`high`
+  and carried the same inherited `state_class`. It did not surface in logs only
+  because the entity is disabled by default; enabling it produced an identical
+  failure. It now declares `device_class: enum`.
+- **`Frost Risk` and `Irrigation Needed` no longer claim to be measurements.**
+  Both return a boolean. Home Assistant accepted these without error — a `bool`
+  is a subclass of `int` — but recorded them as the literal states `True`/`False`
+  and then silently discarded them from long-term statistics, so these sensors
+  never produced usable history. They no longer declare a `state_class`.
+
+### Changed
+
+- `state_class` is no longer set on the shared base class for derived sensors.
+  Each numeric sensor now declares it explicitly, so a non-numeric sensor can no
+  longer inherit an incorrect one by accident. No numeric sensor changed value,
+  unit, `unique_id` or `entity_id`.
+
+### Added
+
+- Platform-level tests that set the integration up inside Home Assistant and
+  assert every entity — including those disabled by default — writes a valid
+  state. The previous tests exercised `native_value` directly, one layer below
+  where Home Assistant validates state, so they could not detect these failures.
+
+### Documentation
+
+- README updated for availability in the HACS default store: installation no
+  longer requires adding a custom repository, plus HACS and My Home Assistant
+  badges and a social preview image.
+
+## [0.1.1] - 2026-05-24
+
+### Fixed
+
+- Compatibility with current Home Assistant releases: corrected `SensorDeviceClass`
+  attribute names and replaced `UnitOfPressure.KILOPASCAL` with `UnitOfPressure.KPA`.
+- `manifest.json` key ordering and other issues reported by hassfest and HACS
+  validation.
+
+### Added
+
+- Branding: repository header image, integration icon, README heading.
+
+## [0.1.0] - 2026-05-22
+
+### Added
+
+- Initial release. Home Assistant custom integration exposing 80+ outdoor
+  environment sensors from the free Open-Meteo APIs, with no API key required:
+  air quality and per-pollutant sub-AQI (EU and US), pollen, UV, weather,
+  agrometeorology, solar radiation including optional Global Tilted Irradiance,
+  and calculated sensors such as comfort index, ventilation score and heat index.
+- Dual coordinator design: air quality polled hourly, weather every 15 minutes,
+  so a failure in one API does not affect the other.
+- Config flow with per-group enable switches and configurable update intervals.
+
+[0.1.2]: https://github.com/nuggetz/ha-outdoor-environment/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/nuggetz/ha-outdoor-environment/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/nuggetz/ha-outdoor-environment/releases/tag/v0.1.0

--- a/custom_components/outdoor_environment/manifest.json
+++ b/custom_components/outdoor_environment/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nuggetz/ha-outdoor-environment/issues",
   "requirements": [],
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/custom_components/outdoor_environment/sensor_derived.py
+++ b/custom_components/outdoor_environment/sensor_derived.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -13,6 +17,7 @@ from .const import (
     CONF_IRRIGATION_THRESHOLD,
     DEFAULT_IRRIGATION_THRESHOLD_MM,
     DOMAIN,
+    EU_SUB_AQI_KEYS,
     calc_ventilation_score,
     get_dominant_eu_pollutant,
     get_pollen_risk,
@@ -40,8 +45,11 @@ class OutdoorDerivedSensor(SensorEntity):
 
     _attr_has_entity_name = True
     _attr_attribution = ATTRIBUTION
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_should_poll = False
+    # NOTE: state_class is deliberately NOT set on the base class. Not every
+    # derived sensor is numeric, and declaring MEASUREMENT here made HA expect
+    # a number from every subclass — non-numeric ones raised ValueError when
+    # their state was written. Numeric subclasses opt in individually.
 
     def __init__(self, entry: ConfigEntry) -> None:
         self._entry = entry
@@ -75,6 +83,7 @@ class OutdoorDerivedSensor(SensorEntity):
 
 class ComfortIndexSensor(OutdoorDerivedSensor):
     _attr_name = "Comfort Index"
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = True
 
@@ -104,6 +113,7 @@ class ComfortIndexSensor(OutdoorDerivedSensor):
 
 class HeatIndexSensor(OutdoorDerivedSensor):
     _attr_name = "Heat Index"
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "°C"
     _attr_entity_registry_enabled_default = True
 
@@ -125,6 +135,7 @@ class HeatIndexSensor(OutdoorDerivedSensor):
 
 class WindChillSensor(OutdoorDerivedSensor):
     _attr_name = "Wind Chill"
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "°C"
     _attr_entity_registry_enabled_default = True
 
@@ -146,6 +157,8 @@ class WindChillSensor(OutdoorDerivedSensor):
 
 class DominantPollutantSensor(OutdoorDerivedSensor):
     _attr_name = "Dominant Pollutant"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(EU_SUB_AQI_KEYS.values())
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = True
 
@@ -161,6 +174,7 @@ class DominantPollutantSensor(OutdoorDerivedSensor):
 
 class PollenTotalRiskSensor(OutdoorDerivedSensor):
     _attr_name = "Pollen Total Risk"
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = True
 
@@ -192,6 +206,7 @@ class PollenTotalRiskSensor(OutdoorDerivedSensor):
 
 class VentilationScoreSensor(OutdoorDerivedSensor):
     _attr_name = "Ventilation Score"
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = True
 
@@ -226,6 +241,7 @@ class VentilationScoreSensor(OutdoorDerivedSensor):
 
 class SolarProductionFactorSensor(OutdoorDerivedSensor):
     _attr_name = "Solar Production Factor"
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = True
 
@@ -245,6 +261,10 @@ class SolarProductionFactorSensor(OutdoorDerivedSensor):
 
 class IrrigationNeededSensor(OutdoorDerivedSensor):
     _attr_name = "Irrigation Needed"
+    # No state_class: native_value is a bool, which HA would accept as
+    # numeric (bool subclasses int) but then record as 'True'/'False' and
+    # silently drop from long-term statistics. Scheduled to move to the
+    # binary_sensor platform in 0.2.0 (breaking change on entity_id).
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = False
 
@@ -284,6 +304,10 @@ class IrrigationNeededSensor(OutdoorDerivedSensor):
 
 class FrostRiskSensor(OutdoorDerivedSensor):
     _attr_name = "Frost Risk"
+    # No state_class: native_value is a bool, which HA would accept as
+    # numeric (bool subclasses int) but then record as 'True'/'False' and
+    # silently drop from long-term statistics. Scheduled to move to the
+    # binary_sensor platform in 0.2.0 (breaking change on entity_id).
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = False
 
@@ -303,6 +327,8 @@ class FrostRiskSensor(OutdoorDerivedSensor):
 
 class LightningRiskSensor(OutdoorDerivedSensor):
     _attr_name = "Lightning Risk"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["none", "low", "medium", "high"]
     _attr_native_unit_of_measurement = None
     _attr_entity_registry_enabled_default = False
 

--- a/custom_components/outdoor_environment/tests/test_sensor_platform.py
+++ b/custom_components/outdoor_environment/tests/test_sensor_platform.py
@@ -1,0 +1,293 @@
+"""Platform-level tests: entities must write valid states inside Home Assistant.
+
+The unit tests in test_sensor_derived.py exercise `native_value` directly, one
+layer below where Home Assistant validates state. `SensorEntity.state` is where
+a non-numeric value on a sensor carrying `state_class=measurement` raises, so it
+is only reachable by setting the platform up against a real `hass`. Without
+these tests a sensor can have a perfectly correct `native_value` and still fail
+to be added to Home Assistant on every startup.
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.outdoor_environment.const import DOMAIN
+
+_AQ_PATH = (
+    "custom_components.outdoor_environment.api_client_aq"
+    ".AirQualityApiClient.fetch"
+)
+_WX_PATH = (
+    "custom_components.outdoor_environment.api_client_weather"
+    ".WeatherApiClient.fetch"
+)
+
+
+def _floats(current: dict) -> dict[str, float | None]:
+    """Mirror what the API clients return: every value cast to float or None."""
+    return {
+        key: (float(val) if isinstance(val, (int, float)) else None)
+        for key, val in current.items()
+        if key != "time"
+    }
+
+
+@contextmanager
+def _patched_apis(aq: dict, wx: dict):
+    with patch(_AQ_PATH, return_value=aq), patch(_WX_PATH, return_value=wx):
+        yield
+
+
+@pytest.fixture
+def entry_all_groups() -> MockConfigEntry:
+    """Config entry with every optional sensor group turned on."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Outdoor Environment",
+        data={
+            "name": "Outdoor Environment",
+            "latitude": 45.46,
+            "longitude": 9.19,
+            "use_home_location": True,
+            "enable_air_quality": True,
+            "enable_pollen": True,
+            "enable_uv": True,
+            "enable_weather": True,
+            "enable_solar": True,
+            "enable_group_a_sub": True,
+            "enable_group_a_sub_us": True,
+            "enable_group_a_extra": True,
+            "enable_group_d_agro": True,
+        },
+        options={},
+    )
+
+
+# Weather payload chosen to drive every derived sensor onto its "active" branch:
+# frost risk true, irrigation needed true, lightning risk "high".
+_WX_EXTREMES: dict[str, float] = {
+    "temperature_2m": 1.0,
+    "relative_humidity_2m": 90.0,
+    "apparent_temperature": 1.0,
+    "dew_point_2m": 0.0,
+    "wind_speed_10m": 2.0,
+    "wind_gusts_10m": 5.0,
+    "wind_direction_10m": 180.0,
+    "precipitation": 0.0,
+    "rain": 0.0,
+    "snowfall": 0.0,
+    "cloud_cover": 80.0,
+    "visibility": 10000.0,
+    "surface_pressure": 1000.0,
+    "weather_code": 95.0,
+    "is_day": 1.0,
+    "sunshine_duration": 0.0,
+    "cape": 2500.0,
+    "wet_bulb_temperature_2m": 1.0,
+    "vapour_pressure_deficit": 0.1,
+    "et0_fao_evapotranspiration": 5.0,
+    "shortwave_radiation": 100.0,
+    "direct_radiation": 50.0,
+    "diffuse_radiation": 50.0,
+    "direct_normal_irradiance": 80.0,
+    "terrestrial_radiation": 200.0,
+}
+
+
+def _entity_ids(hass, entry) -> list[str]:
+    registry = er.async_get(hass)
+    return sorted(
+        e.entity_id
+        for e in registry.entities.values()
+        if e.config_entry_id == entry.entry_id
+    )
+
+
+def _state_errors(caplog) -> list[str]:
+    """Entity-platform errors raised while adding or updating entities."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+    ]
+
+
+async def _enable_all_entities(hass, entry) -> None:
+    """Clear `disabled_by` on every entity, then reload so they get added."""
+    registry = er.async_get(hass)
+    for entity_id in _entity_ids(hass, entry):
+        if registry.entities[entity_id].disabled_by is not None:
+            registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_default_config_adds_every_entity_without_error(
+    hass, entry_all_groups, aq_response, wx_response, caplog
+):
+    """Regression: dominant_pollutant used to raise on every startup.
+
+    It returns a pollutant slug ('pm2_5'), but inherited state_class=measurement
+    from its base class, so HA rejected the state as non-numeric.
+    """
+    caplog.set_level(logging.ERROR)
+    entry_all_groups.add_to_hass(hass)
+
+    with _patched_apis(_floats(aq_response["current"]), _floats(wx_response["current"])):
+        assert await hass.config_entries.async_setup(entry_all_groups.entry_id)
+        await hass.async_block_till_done()
+
+    assert _state_errors(caplog) == []
+
+    registry = er.async_get(hass)
+    for entity_id in _entity_ids(hass, entry_all_groups):
+        if registry.entities[entity_id].disabled_by is not None:
+            continue
+        assert hass.states.get(entity_id) is not None, f"{entity_id} has no state"
+
+
+async def test_every_entity_including_disabled_writes_a_state(
+    hass, entry_all_groups, aq_response, caplog
+):
+    """Regression: lightning_risk had the same defect, hidden behind
+    entity_registry_enabled_default=False. Enabling it crashed the platform.
+    """
+    caplog.set_level(logging.ERROR)
+    entry_all_groups.add_to_hass(hass)
+
+    aq = _floats(aq_response["current"])
+    with _patched_apis(aq, _WX_EXTREMES):
+        assert await hass.config_entries.async_setup(entry_all_groups.entry_id)
+        await hass.async_block_till_done()
+        await _enable_all_entities(hass, entry_all_groups)
+
+    assert _state_errors(caplog) == []
+
+    entity_ids = _entity_ids(hass, entry_all_groups)
+    assert len(entity_ids) > 50, "expected the full entity set to be registered"
+    for entity_id in entity_ids:
+        assert hass.states.get(entity_id) is not None, f"{entity_id} has no state"
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected"),
+    [
+        # o3 has the highest EU sub-AQI (32) in the fixture, so it dominates.
+        ("sensor.outdoor_environment_dominant_pollutant", "o3"),
+        ("sensor.outdoor_environment_lightning_risk", "high"),
+        ("sensor.outdoor_environment_frost_risk", "True"),
+        ("sensor.outdoor_environment_irrigation_needed", "True"),
+    ],
+)
+async def test_non_numeric_sensors_expose_their_value(
+    hass, entry_all_groups, aq_response, entity_id, expected
+):
+    """The non-numeric derived sensors must reach HA with their real value."""
+    entry_all_groups.add_to_hass(hass)
+
+    with _patched_apis(_floats(aq_response["current"]), _WX_EXTREMES):
+        assert await hass.config_entries.async_setup(entry_all_groups.entry_id)
+        await hass.async_block_till_done()
+        await _enable_all_entities(hass, entry_all_groups)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} was never added"
+    assert state.state == expected
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "options"),
+    [
+        (
+            "sensor.outdoor_environment_dominant_pollutant",
+            ["pm2_5", "pm10", "no2", "o3", "so2"],
+        ),
+        (
+            "sensor.outdoor_environment_lightning_risk",
+            ["none", "low", "medium", "high"],
+        ),
+    ],
+)
+async def test_enum_sensors_declare_options_and_no_state_class(
+    hass, entry_all_groups, aq_response, entity_id, options
+):
+    """Categorical sensors are enums, not measurements.
+
+    `options` must cover every value native_value can return, otherwise HA
+    raises for the values that are missing from the list.
+    """
+    entry_all_groups.add_to_hass(hass)
+
+    with _patched_apis(_floats(aq_response["current"]), _WX_EXTREMES):
+        assert await hass.config_entries.async_setup(entry_all_groups.entry_id)
+        await hass.async_block_till_done()
+        await _enable_all_entities(hass, entry_all_groups)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes.get("device_class") == "enum"
+    assert state.attributes.get("options") == options
+    assert state.attributes.get("state_class") is None
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "sensor.outdoor_environment_frost_risk",
+        "sensor.outdoor_environment_irrigation_needed",
+    ],
+)
+async def test_boolean_sensors_carry_no_state_class(
+    hass, entry_all_groups, aq_response, entity_id
+):
+    """Booleans must not claim to be measurements.
+
+    HA accepts a bool as numeric (bool subclasses int), so this never raised —
+    it silently produced 'True'/'False' states that the recorder then dropped
+    from long-term statistics. These move to binary_sensor in 0.2.0.
+    """
+    entry_all_groups.add_to_hass(hass)
+
+    with _patched_apis(_floats(aq_response["current"]), _WX_EXTREMES):
+        assert await hass.config_entries.async_setup(entry_all_groups.entry_id)
+        await hass.async_block_till_done()
+        await _enable_all_entities(hass, entry_all_groups)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes.get("state_class") is None
+
+
+def test_every_derived_sensor_is_covered_by_this_module():
+    """Guard: a new derived sensor must not silently escape platform testing."""
+    from custom_components.outdoor_environment import sensor_derived
+
+    known = {
+        "ComfortIndexSensor",
+        "HeatIndexSensor",
+        "WindChillSensor",
+        "DominantPollutantSensor",
+        "PollenTotalRiskSensor",
+        "VentilationScoreSensor",
+        "SolarProductionFactorSensor",
+        "IrrigationNeededSensor",
+        "FrostRiskSensor",
+        "LightningRiskSensor",
+    }
+    actual = {
+        name
+        for name, obj in vars(sensor_derived).items()
+        if isinstance(obj, type)
+        and issubclass(obj, sensor_derived.OutdoorDerivedSensor)
+        and obj is not sensor_derived.OutdoorDerivedSensor
+    }
+    assert actual == known, (
+        "Derived sensors changed. Add the new sensor to the platform tests above "
+        "and confirm its native_value type matches its state_class."
+    )


### PR DESCRIPTION
## The bug

`OutdoorDerivedSensor` set `state_class = SensorStateClass.MEASUREMENT` on the base
class, so **every** derived sensor inherited it — including the three that do not
return numbers.

`Dominant Pollutant` returns a pollutant slug (`o3`, `pm2_5`, …). Home Assistant
therefore rejected its state:

```
ValueError: Sensor sensor.outdoor_environment_dominant_pollutant has device class
'None', state class 'measurement' unit 'None' and suggested precision 'None' thus
indicating it has a numeric value; however, it has the non-numeric value: 'pm2_5'
```

The entity was never added, and the error repeated on every coordinator refresh
(~40 errors in 6 hours of uptime on a real install).

**Scope:** the `european_aqi_*` keys are always fetched — `enable_group_a_sub` only
gates entity *creation*, not the API request — so this hit every installation
receiving European air-quality data, in the default configuration.

## Also fixed

| Sensor | `native_value` | Symptom |
|---|---|---|
| `Dominant Pollutant` | `str` | Crash on add + every update (live) |
| `Lightning Risk` | `str` | Identical crash, hidden behind `enabled_default=False` |
| `Frost Risk` | `bool` | No crash (`bool` subclasses `int`), but recorded as `'True'`/`'False'` and silently dropped from long-term statistics |
| `Irrigation Needed` | `bool` | Same |

## The fix

- `state_class` is now **opt-in per sensor** instead of imposed by the base class,
  so a non-numeric sensor can no longer inherit a wrong one by accident. This is
  the root cause, not just the symptom.
- The two categorical sensors declare `device_class: enum` with explicit `options`.
- The two boolean sensors declare no `state_class`. They are slated to move to the
  `binary_sensor` platform in 0.2.0, which is a breaking change on `entity_id` and
  deliberately kept out of a patch release.

No `unique_id`, `entity_id`, unit or numeric value changed. **Not breaking.**

## Why the tests did not catch this

`test_sensor_derived.py` exercises `native_value` directly against mocked entries.
`native_value` was always correct — the failure is in `SensorEntity.state`, one
layer above, which only runs when the platform is set up against a real `hass`.
There was no platform-level test at all, and `DominantPollutantSensor` had no test
of any kind.

This PR adds `tests/test_sensor_platform.py`: it sets the integration up inside
Home Assistant and asserts every entity — including registry-disabled ones — writes
a valid state. **On the previous code these tests fail 8/11 with the exact
production error; on this code all pass.** Suite goes from 53 to 64 tests.

A guard test also fails if a new derived sensor is added without being covered here.

## Release

Version bumped to 0.1.2. `CHANGELOG.md` added (Keep a Changelog) with retroactive
entries for 0.1.0 and 0.1.1, since the project had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)