### PR TITLE
fix: poll only APIs required by enabled sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **Adding a `panel_tilt` will automatically enabled GTI.**
+- **PollenTotalRisk now reports unknown for missing values.** Pollen
+  values are only available for EU locations, enabling Group B Pollen
+  in a non-EU location will cause PollenTotalRisk to report `unknown`
+  and not `0.`
+
+### Changed
+
+- **Open-Meteo polling more efficient.** Polling of the weather and
+  air quality APIs is only done when there is demand for data from
+  your system in the form of active sensors.  For example, if you
+  disable all weather sensors, the weather api will no longer be
+  polled.
+- **Derived sensors gated on data availability.** Derived sensors
+  are only automatically enabled when the API they require is already
+  being polled.  Manually enabled a derived sensor will trigger
+  polling demand.
+
 ## [0.1.2] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Go to **Settings → Devices & Services → Add Integration → Outdoor Environm
 
 All settings are adjustable later via **Configure** (options flow), including update intervals, irrigation threshold, and advanced sensor groups.
 
+> Runtime polling is conditional: if no enabled sensor group depends on an Open-Meteo API, that API stays idle and no startup or periodic refresh is triggered.
+
 ---
 
 ## Automation examples

--- a/custom_components/outdoor_environment/__init__.py
+++ b/custom_components/outdoor_environment/__init__.py
@@ -15,6 +15,7 @@ from .const import (
     DEFAULT_AQ_UPDATE_MINUTES,
     DEFAULT_WEATHER_UPDATE_MINUTES,
     DOMAIN,
+    get_api_demand,
 )
 from .coordinator_aq import AirQualityCoordinator
 from .coordinator_weather import WeatherCoordinator
@@ -32,40 +33,63 @@ class OutdoorEnvironmentData:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Outdoor Environment from a config entry."""
+    cfg = {**entry.data, **entry.options}
     lat: float = entry.data[CONF_LATITUDE]
     lon: float = entry.data[CONF_LONGITUDE]
 
+    demand_aq, demand_weather = get_api_demand(cfg)
+
     # Options take precedence over data for interval settings
-    aq_interval = int(
-        entry.options.get(
-            CONF_AQ_UPDATE_INTERVAL,
-            entry.data.get(CONF_AQ_UPDATE_INTERVAL, DEFAULT_AQ_UPDATE_MINUTES),
+    aq_interval = (
+        int(
+            cfg.get(
+                CONF_AQ_UPDATE_INTERVAL,
+                DEFAULT_AQ_UPDATE_MINUTES,
+            )
         )
+        if demand_aq
+        else None
     )
-    weather_interval = int(
-        entry.options.get(
-            CONF_WEATHER_UPDATE_INTERVAL,
-            entry.data.get(CONF_WEATHER_UPDATE_INTERVAL, DEFAULT_WEATHER_UPDATE_MINUTES),
+    weather_interval = (
+        int(
+            cfg.get(
+                CONF_WEATHER_UPDATE_INTERVAL,
+                DEFAULT_WEATHER_UPDATE_MINUTES,
+            )
         )
+        if demand_weather
+        else None
     )
-    cfg = {**entry.data, **entry.options}
+    coordinator_aq = AirQualityCoordinator(
+        hass,
+        lat,
+        lon,
+        aq_interval,
+        config_entry=entry,
+    )
     panel_tilt: float | None = cfg.get(CONF_PANEL_TILT)
     panel_azimuth: float | None = cfg.get(CONF_PANEL_AZIMUTH)
-
-    coordinator_aq = AirQualityCoordinator(hass, lat, lon, aq_interval)
     coordinator_weather = WeatherCoordinator(
-        hass, lat, lon, weather_interval, panel_tilt, panel_azimuth
+        hass,
+        lat,
+        lon,
+        weather_interval,
+        panel_tilt=panel_tilt,
+        panel_azimuth=panel_azimuth,
+        config_entry=entry,
     )
 
-    try:
-        await coordinator_aq.async_config_entry_first_refresh()
-    except Exception as err:
-        raise ConfigEntryNotReady(f"AQ API unavailable: {err}") from err
+    if demand_aq:
+        try:
+            await coordinator_aq.async_config_entry_first_refresh()
+        except Exception as err:
+            raise ConfigEntryNotReady(f"AQ API unavailable: {err}") from err
 
-    try:
-        await coordinator_weather.async_config_entry_first_refresh()
-    except Exception as err:
-        raise ConfigEntryNotReady(f"Weather API unavailable: {err}") from err
+    if demand_weather:
+        try:
+            await coordinator_weather.async_config_entry_first_refresh()
+        except Exception as err:
+            raise ConfigEntryNotReady(f"Weather API unavailable: {err}") from err
 
     entry.runtime_data = OutdoorEnvironmentData(
         coordinator_aq=coordinator_aq,

--- a/custom_components/outdoor_environment/const.py
+++ b/custom_components/outdoor_environment/const.py
@@ -31,6 +31,25 @@ CONF_ENABLE_GROUP_A_SUB_US = "enable_group_a_sub_us"
 CONF_ENABLE_GROUP_A_EXTRA = "enable_group_a_extra"
 CONF_ENABLE_GROUP_D_AGRO = "enable_group_d_agro"
 
+
+def get_api_demand(cfg: dict[str, object]) -> tuple[bool, bool]:
+    """Return whether the AQ and weather APIs are required by configured groups."""
+    demand_aq = bool(
+        cfg.get(CONF_ENABLE_AIR_QUALITY, True)
+        or cfg.get(CONF_ENABLE_GROUP_A_SUB, False)
+        or cfg.get(CONF_ENABLE_GROUP_A_SUB_US, False)
+        or cfg.get(CONF_ENABLE_GROUP_A_EXTRA, False)
+        or cfg.get(CONF_ENABLE_POLLEN, True)
+        or cfg.get(CONF_ENABLE_UV, True)
+    )
+    demand_weather = bool(
+        cfg.get(CONF_ENABLE_WEATHER, True)
+        or cfg.get(CONF_ENABLE_SOLAR, True)
+        or cfg.get(CONF_ENABLE_GROUP_D_AGRO, False)
+    )
+    return demand_aq, demand_weather
+
+
 # Attribution
 ATTRIBUTION = "Data provided by Open-Meteo (CC BY 4.0)"
 

--- a/custom_components/outdoor_environment/coordinator_aq.py
+++ b/custom_components/outdoor_environment/coordinator_aq.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -21,7 +22,9 @@ class AirQualityCoordinator(DataUpdateCoordinator[dict[str, float | None]]):
         hass: HomeAssistant,
         lat: float,
         lon: float,
-        update_interval_minutes: int = DEFAULT_AQ_UPDATE_MINUTES,
+        update_interval_minutes: int | None = DEFAULT_AQ_UPDATE_MINUTES,
+        *,
+        config_entry: ConfigEntry | None = None,
     ) -> None:
         self._client = AirQualityApiClient(
             async_get_clientsession(hass), lat, lon
@@ -30,7 +33,10 @@ class AirQualityCoordinator(DataUpdateCoordinator[dict[str, float | None]]):
             hass,
             _LOGGER,
             name="outdoor_environment_aq",
-            update_interval=timedelta(minutes=update_interval_minutes),
+            update_interval=(
+                None if update_interval_minutes is None else timedelta(minutes=update_interval_minutes)
+            ),
+            config_entry=config_entry,
         )
 
     async def _async_update_data(self) -> dict[str, float | None]:

--- a/custom_components/outdoor_environment/coordinator_weather.py
+++ b/custom_components/outdoor_environment/coordinator_weather.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -22,18 +23,27 @@ class WeatherCoordinator(DataUpdateCoordinator[dict[str, float | None]]):
         hass: HomeAssistant,
         lat: float,
         lon: float,
-        update_interval_minutes: int = DEFAULT_WEATHER_UPDATE_MINUTES,
+        update_interval_minutes: int | None = DEFAULT_WEATHER_UPDATE_MINUTES,
+        *,
         panel_tilt: float | None = None,
         panel_azimuth: float | None = None,
+        config_entry: ConfigEntry | None = None,
     ) -> None:
         self._client = WeatherApiClient(
-            async_get_clientsession(hass), lat, lon, panel_tilt, panel_azimuth
+            async_get_clientsession(hass),
+            lat,
+            lon,
+            panel_tilt,
+            panel_azimuth,
         )
         super().__init__(
             hass,
             _LOGGER,
             name="outdoor_environment_weather",
-            update_interval=timedelta(minutes=update_interval_minutes),
+            update_interval=(
+                None if update_interval_minutes is None else timedelta(minutes=update_interval_minutes)
+            ),
+            config_entry=config_entry,
         )
 
     async def _async_update_data(self) -> dict[str, float | None]:

--- a/custom_components/outdoor_environment/sensor.py
+++ b/custom_components/outdoor_environment/sensor.py
@@ -44,6 +44,7 @@ from .const import (
     WMO_DESCRIPTIONS,
     get_aqi_eu_category,
     get_aqi_us_category,
+    get_api_demand,
     get_dominant_eu_pollutant,
     get_pollen_risk,
     get_uv_category,
@@ -483,6 +484,7 @@ async def async_setup_entry(
     weather = runtime.coordinator_weather
 
     cfg = {**entry.data, **entry.options}
+    demand_aq, demand_weather = get_api_demand(cfg)
     lat: float = entry.data.get("latitude", 0.0)
     lon: float = entry.data.get("longitude", 0.0)
     in_europe = is_europe(lat, lon)
@@ -541,6 +543,6 @@ async def async_setup_entry(
             entities.append(GtiSensor(weather, entry))
 
     # Group F — derived sensors
-    entities += create_derived_sensors(entry)
+    entities += create_derived_sensors(entry, cfg, demand_aq, demand_weather)
 
     async_add_entities(entities)

--- a/custom_components/outdoor_environment/sensor_derived.py
+++ b/custom_components/outdoor_environment/sensor_derived.py
@@ -8,17 +8,18 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     ATTRIBUTION,
+    CONF_ENABLE_POLLEN,
     CONF_IRRIGATION_THRESHOLD,
     DEFAULT_IRRIGATION_THRESHOLD_MM,
     DOMAIN,
     EU_SUB_AQI_KEYS,
     calc_ventilation_score,
+    get_api_demand,
     get_dominant_eu_pollutant,
     get_pollen_risk,
     heat_index,
@@ -51,18 +52,18 @@ class OutdoorDerivedSensor(SensorEntity):
     # a number from every subclass — non-numeric ones raised ValueError when
     # their state was written. Numeric subclasses opt in individually.
 
-    def __init__(self, entry: ConfigEntry) -> None:
+    def __init__(self, entry: ConfigEntry, *, coordinator_types: tuple[str, ...]) -> None:
         self._entry = entry
+        self._coordinator_types = coordinator_types
         self._attr_device_info = _device_info(entry)
 
     async def async_added_to_hass(self) -> None:
         data: OutdoorEnvironmentData = self._entry.runtime_data
-        self.async_on_remove(
-            data.coordinator_aq.async_add_listener(self._handle_update)
-        )
-        self.async_on_remove(
-            data.coordinator_weather.async_add_listener(self._handle_update)
-        )
+        for coordinator_type in self._coordinator_types:
+            if coordinator_type == "aq":
+                self.async_on_remove(data.coordinator_aq.async_add_listener(self._handle_update))
+            elif coordinator_type == "weather":
+                self.async_on_remove(data.coordinator_weather.async_add_listener(self._handle_update))
 
     @callback
     def _handle_update(self) -> None:
@@ -88,7 +89,7 @@ class ComfortIndexSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = True
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_comfort_index"
 
     @property
@@ -118,7 +119,7 @@ class HeatIndexSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = True
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_heat_index"
 
     @property
@@ -140,7 +141,7 @@ class WindChillSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = True
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_wind_chill"
 
     @property
@@ -163,7 +164,7 @@ class DominantPollutantSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = True
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("aq",))
         self._attr_unique_id = f"{entry.entry_id}_dominant_pollutant"
 
     @property
@@ -189,18 +190,27 @@ class PollenTotalRiskSensor(OutdoorDerivedSensor):
     }
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("aq",))
         self._attr_unique_id = f"{entry.entry_id}_pollen_total_risk"
 
     @property
     def native_value(self) -> int | None:
         aq = self._aq()
         max_level = 0
+        saw_numeric_reading = False
         for key, species in self._SPECIES_KEYS.items():
             val = aq.get(key)
-            if val is not None:
-                level = self._RISK_ORDER.get(get_pollen_risk(species, val), 0)
-                max_level = max(max_level, level)
+            if val is None:
+                continue
+            if not isinstance(val, (int, float)):
+                continue
+            saw_numeric_reading = True
+            if val == 0:
+                continue
+            level = self._RISK_ORDER.get(get_pollen_risk(species, val), 0)
+            max_level = max(max_level, level)
+        if not saw_numeric_reading:
+            return None
         return max_level
 
 
@@ -211,7 +221,7 @@ class VentilationScoreSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = True
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("aq", "weather"))
         self._attr_unique_id = f"{entry.entry_id}_ventilation_score"
 
     @property
@@ -246,7 +256,7 @@ class SolarProductionFactorSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = True
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_solar_production_factor"
 
     @property
@@ -269,7 +279,7 @@ class IrrigationNeededSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_irrigation_needed"
         self._threshold: float = float(
             entry.options.get(
@@ -312,7 +322,7 @@ class FrostRiskSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_frost_risk"
 
     @property
@@ -333,7 +343,7 @@ class LightningRiskSensor(OutdoorDerivedSensor):
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, entry: ConfigEntry) -> None:
-        super().__init__(entry)
+        super().__init__(entry, coordinator_types=("weather",))
         self._attr_unique_id = f"{entry.entry_id}_lightning_risk"
 
     @property
@@ -356,17 +366,38 @@ class LightningRiskSensor(OutdoorDerivedSensor):
 # Factory
 # ---------------------------------------------------------------------------
 
-def create_derived_sensors(entry: ConfigEntry) -> list[SensorEntity]:
-    """Return all derived sensor instances for this config entry."""
-    return [
-        ComfortIndexSensor(entry),
-        HeatIndexSensor(entry),
-        WindChillSensor(entry),
-        DominantPollutantSensor(entry),
-        PollenTotalRiskSensor(entry),
-        VentilationScoreSensor(entry),
-        SolarProductionFactorSensor(entry),
-        IrrigationNeededSensor(entry),
-        FrostRiskSensor(entry),
-        LightningRiskSensor(entry),
-    ]
+def create_derived_sensors(
+    entry: ConfigEntry,
+    cfg: dict[str, Any],
+    demand_aq: bool | None = None,
+    demand_weather: bool | None = None,
+) -> list[SensorEntity]:
+    """Return derived sensors whose required input APIs are active."""
+    if demand_aq is None or demand_weather is None:
+        demand_aq, demand_weather = get_api_demand(cfg)
+
+    sensors: list[SensorEntity] = []
+
+    if demand_weather:
+        sensors.extend(
+            [
+                ComfortIndexSensor(entry),
+                HeatIndexSensor(entry),
+                WindChillSensor(entry),
+                FrostRiskSensor(entry),
+                LightningRiskSensor(entry),
+                IrrigationNeededSensor(entry),
+                SolarProductionFactorSensor(entry),
+            ]
+        )
+
+    if demand_aq and demand_weather:
+        sensors.append(VentilationScoreSensor(entry))
+
+    if demand_aq:
+        sensors.append(DominantPollutantSensor(entry))
+
+    if demand_aq and cfg.get(CONF_ENABLE_POLLEN, True):
+        sensors.append(PollenTotalRiskSensor(entry))
+
+    return sensors

--- a/custom_components/outdoor_environment/tests/test_api_client_weather.py
+++ b/custom_components/outdoor_environment/tests/test_api_client_weather.py
@@ -30,6 +30,19 @@ def session() -> MagicMock:
 
 
 @pytest.mark.asyncio
+async def test_fetch_returns_weather_payload(session, wx_response):
+    session.get.return_value = _make_response(wx_response)
+    client = WeatherApiClient(session, 45.46, 9.19)
+    result = await client.fetch()
+
+    assert result["temperature_2m"] == 22.5
+    assert result["weather_code"] == 2.0
+    params = session.get.call_args.kwargs["params"]
+    assert params["latitude"] == 45.46
+    assert params["longitude"] == 9.19
+
+
+@pytest.mark.asyncio
 async def test_fetch_without_gti(session, wx_response):
     session.get.return_value = _make_response(wx_response)
     client = WeatherApiClient(session, 45.46, 9.19)
@@ -38,7 +51,6 @@ async def test_fetch_without_gti(session, wx_response):
     assert result["temperature_2m"] == 22.5
     assert "global_tilted_irradiance" not in result
 
-    # Verify GTI params were NOT added to the URL
     call_kwargs = session.get.call_args
     params = call_kwargs[1].get("params", call_kwargs[0][1] if len(call_kwargs[0]) > 1 else {})
     assert "tilt" not in str(params)

--- a/custom_components/outdoor_environment/tests/test_runtime_demand.py
+++ b/custom_components/outdoor_environment/tests/test_runtime_demand.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.exceptions import ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.outdoor_environment import async_setup_entry
+from custom_components.outdoor_environment.const import (
+    CONF_ENABLE_AIR_QUALITY,
+    CONF_ENABLE_GROUP_A_EXTRA,
+    CONF_ENABLE_GROUP_A_SUB,
+    CONF_ENABLE_GROUP_A_SUB_US,
+    CONF_ENABLE_GROUP_D_AGRO,
+    CONF_ENABLE_POLLEN,
+    CONF_ENABLE_SOLAR,
+    CONF_ENABLE_UV,
+    CONF_ENABLE_WEATHER,
+    DOMAIN,
+)
+from custom_components.outdoor_environment.coordinator_aq import AirQualityCoordinator
+from custom_components.outdoor_environment.coordinator_weather import WeatherCoordinator
+from custom_components.outdoor_environment.sensor_derived import (
+    ComfortIndexSensor,
+    DominantPollutantSensor,
+    FrostRiskSensor,
+    HeatIndexSensor,
+    IrrigationNeededSensor,
+    LightningRiskSensor,
+    PollenTotalRiskSensor,
+    SolarProductionFactorSensor,
+    VentilationScoreSensor,
+    WindChillSensor,
+    create_derived_sensors,
+)
+
+_ALL_GROUPS_DISABLED = {
+    CONF_ENABLE_AIR_QUALITY: False,
+    CONF_ENABLE_GROUP_A_SUB: False,
+    CONF_ENABLE_GROUP_A_SUB_US: False,
+    CONF_ENABLE_GROUP_A_EXTRA: False,
+    CONF_ENABLE_POLLEN: False,
+    CONF_ENABLE_UV: False,
+    CONF_ENABLE_WEATHER: False,
+    CONF_ENABLE_SOLAR: False,
+    CONF_ENABLE_GROUP_D_AGRO: False,
+}
+
+
+def _entry(data: dict | None = None, options: dict | None = None) -> MockConfigEntry:
+    config = {
+        "latitude": 45.46,
+        "longitude": 9.19,
+        "enable_air_quality": True,
+        "enable_pollen": True,
+        "enable_uv": True,
+        "enable_weather": True,
+        "enable_solar": True,
+        "enable_group_a_sub": False,
+        "enable_group_a_sub_us": False,
+        "enable_group_a_extra": False,
+        "enable_group_d_agro": False,
+    }
+    config.update(data or {})
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Outdoor Environment",
+        data=config,
+        options=options or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_coordinators_accept_none_and_expose_none_interval(hass):
+    assert WeatherCoordinator(hass, 45.46, 9.19, update_interval_minutes=None).update_interval is None
+    assert AirQualityCoordinator(hass, 45.46, 9.19, update_interval_minutes=None).update_interval is None
+
+
+@pytest.mark.asyncio
+async def test_numeric_intervals_preserve_timedelta(hass):
+    assert WeatherCoordinator(hass, 45.46, 9.19, update_interval_minutes=10).update_interval == timedelta(minutes=10)
+    assert AirQualityCoordinator(hass, 45.46, 9.19, update_interval_minutes=30).update_interval == timedelta(minutes=30)
+
+
+@pytest.mark.asyncio
+async def test_forecast_startup_fetch_skipped_when_weather_related_groups_are_disabled(hass):
+    entry = _entry({
+        CONF_ENABLE_WEATHER: False,
+        CONF_ENABLE_SOLAR: False,
+        CONF_ENABLE_GROUP_D_AGRO: False,
+        CONF_ENABLE_AIR_QUALITY: True,
+    })
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.outdoor_environment.coordinator_weather.WeatherCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        side_effect=AssertionError("weather refresh should be skipped"),
+    ) as weather_refresh, patch(
+        "custom_components.outdoor_environment.coordinator_aq.AirQualityCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as aq_refresh:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    weather_refresh.assert_not_awaited()
+    aq_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_aq_startup_fetch_skipped_when_all_aq_backed_groups_are_disabled(hass):
+    entry = _entry({**_ALL_GROUPS_DISABLED, CONF_ENABLE_WEATHER: True})
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.outdoor_environment.coordinator_aq.AirQualityCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        side_effect=AssertionError("aq refresh should be skipped"),
+    ) as aq_refresh, patch(
+        "custom_components.outdoor_environment.coordinator_weather.WeatherCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as weather_refresh:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    aq_refresh.assert_not_awaited()
+    weather_refresh.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "enabled_group",
+    [
+        CONF_ENABLE_AIR_QUALITY,
+        CONF_ENABLE_GROUP_A_SUB,
+        CONF_ENABLE_GROUP_A_SUB_US,
+        CONF_ENABLE_GROUP_A_EXTRA,
+        CONF_ENABLE_POLLEN,
+        CONF_ENABLE_UV,
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_aq_group_independently_demands_aq_refresh(hass, enabled_group):
+    entry = _entry({**_ALL_GROUPS_DISABLED, enabled_group: True})
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.outdoor_environment.coordinator_aq.AirQualityCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as aq_refresh:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    aq_refresh.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "enabled_group",
+    [
+        CONF_ENABLE_SOLAR,
+        CONF_ENABLE_GROUP_D_AGRO,
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_weather_group_independently_demands_weather_refresh(hass, enabled_group):
+    entry = _entry({**_ALL_GROUPS_DISABLED, enabled_group: True})
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.outdoor_environment.coordinator_weather.WeatherCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as weather_refresh:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    weather_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_pollen_flag_defaults_true_and_demands_aq(hass):
+    data = {
+        "latitude": 45.46,
+        "longitude": 9.19,
+        **{
+            key: value
+            for key, value in _ALL_GROUPS_DISABLED.items()
+            if key != CONF_ENABLE_POLLEN
+        },
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Outdoor Environment",
+        data=data,
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.outdoor_environment.coordinator_aq.AirQualityCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as aq_refresh:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    aq_refresh.assert_awaited_once()
+    assert {type(sensor) for sensor in create_derived_sensors(entry, {**entry.data, **entry.options})} == {
+        PollenTotalRiskSensor,
+        DominantPollutantSensor,
+    }
+
+
+@pytest.mark.asyncio
+async def test_demand_is_independent_across_apis(hass):
+    entry = _entry({
+        CONF_ENABLE_AIR_QUALITY: True,
+        CONF_ENABLE_WEATHER: False,
+        CONF_ENABLE_SOLAR: False,
+        CONF_ENABLE_GROUP_D_AGRO: False,
+    })
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.outdoor_environment.coordinator_aq.AirQualityCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as aq_refresh, patch(
+        "custom_components.outdoor_environment.coordinator_weather.WeatherCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        side_effect=AssertionError("weather refresh should be skipped"),
+    ) as weather_refresh:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    aq_refresh.assert_awaited_once()
+    weather_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_demanded_api_failure_blocks_setup_but_undemanded_failure_does_not(hass):
+    requested_entry = _entry({CONF_ENABLE_AIR_QUALITY: True, CONF_ENABLE_WEATHER: False, CONF_ENABLE_SOLAR: False, CONF_ENABLE_GROUP_D_AGRO: False})
+    requested_entry.add_to_hass(hass)
+    with patch(
+        "custom_components.outdoor_environment.coordinator_aq.AirQualityCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("aq boom"),
+    ):
+        assert not await hass.config_entries.async_setup(requested_entry.entry_id)
+
+    undemanded_entry = _entry({CONF_ENABLE_AIR_QUALITY: False, CONF_ENABLE_GROUP_A_SUB: False, CONF_ENABLE_GROUP_A_SUB_US: False, CONF_ENABLE_GROUP_A_EXTRA: False, CONF_ENABLE_POLLEN: False, CONF_ENABLE_UV: False, CONF_ENABLE_WEATHER: False, CONF_ENABLE_SOLAR: False, CONF_ENABLE_GROUP_D_AGRO: False})
+    undemanded_entry.add_to_hass(hass)
+    with patch(
+        "custom_components.outdoor_environment.coordinator_weather.WeatherCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("weather boom"),
+    ):
+        assert await hass.config_entries.async_setup(undemanded_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("cfg", "expected"),
+    [
+        (
+            {CONF_ENABLE_WEATHER: True},
+            {
+                ComfortIndexSensor,
+                HeatIndexSensor,
+                WindChillSensor,
+                FrostRiskSensor,
+                LightningRiskSensor,
+                IrrigationNeededSensor,
+                SolarProductionFactorSensor,
+            },
+        ),
+        (
+            {CONF_ENABLE_AIR_QUALITY: True, CONF_ENABLE_POLLEN: False},
+            {DominantPollutantSensor},
+        ),
+        (
+            {CONF_ENABLE_POLLEN: True},
+            {DominantPollutantSensor, PollenTotalRiskSensor},
+        ),
+        (
+            {CONF_ENABLE_WEATHER: True, CONF_ENABLE_POLLEN: True},
+            {
+                ComfortIndexSensor,
+                HeatIndexSensor,
+                WindChillSensor,
+                FrostRiskSensor,
+                LightningRiskSensor,
+                IrrigationNeededSensor,
+                SolarProductionFactorSensor,
+                DominantPollutantSensor,
+                PollenTotalRiskSensor,
+                VentilationScoreSensor,
+            },
+        ),
+        ({**_ALL_GROUPS_DISABLED}, set()),
+    ],
+)
+def test_derived_sensor_creation_respects_group_dependencies(cfg, expected):
+    entry = _entry({**_ALL_GROUPS_DISABLED, **cfg})
+    sensors = create_derived_sensors(entry, {**entry.data, **entry.options})
+    sensor_types = {type(sensor) for sensor in sensors}
+    assert sensor_types == expected

--- a/custom_components/outdoor_environment/tests/test_sensor_derived.py
+++ b/custom_components/outdoor_environment/tests/test_sensor_derived.py
@@ -1,6 +1,8 @@
 """Tests for derived sensor calculations (pure functions and sensor values)."""
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from custom_components.outdoor_environment.const import (
@@ -11,10 +13,12 @@ from custom_components.outdoor_environment.const import (
 )
 from custom_components.outdoor_environment.sensor_derived import (
     ComfortIndexSensor,
+    DominantPollutantSensor,
     FrostRiskSensor,
     HeatIndexSensor,
     IrrigationNeededSensor,
     LightningRiskSensor,
+    PollenTotalRiskSensor,
     SolarProductionFactorSensor,
     VentilationScoreSensor,
     WindChillSensor,
@@ -201,6 +205,60 @@ def test_derived_sensors_partial_data_aq_only():
     entry = _make_entry({"european_aqi": 30.0}, {})
     heat = HeatIndexSensor(entry)
     assert heat.native_value is None  # depends on weather data
+
+
+@pytest.mark.parametrize(
+    ("aq_data", "expected"),
+    [
+        ({"grass_pollen": 0.0, "birch_pollen": 0.0}, 0),
+        ({"grass_pollen": 0.0, "birch_pollen": None}, 0),
+        ({"grass_pollen": None, "birch_pollen": None}, None),
+        ({}, None),
+    ],
+)
+def test_pollen_total_risk_zero_and_missing_values(aq_data, expected):
+    entry = _make_entry(aq_data, {})
+    sensor = PollenTotalRiskSensor(entry)
+    assert sensor.native_value == expected
+
+
+@pytest.mark.parametrize(
+    ("sensor_cls", "expected_aq", "expected_weather"),
+    [
+        (ComfortIndexSensor, 0, 1),
+        (DominantPollutantSensor, 1, 0),
+        (VentilationScoreSensor, 1, 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_derived_sensors_only_subscribe_to_used_coordinators(
+    sensor_cls,
+    expected_aq,
+    expected_weather,
+):
+    from custom_components.outdoor_environment import OutdoorEnvironmentData
+
+    aq = MagicMock()
+    weather = MagicMock()
+    aq.async_add_listener = MagicMock(return_value=lambda: None)
+    weather.async_add_listener = MagicMock(return_value=lambda: None)
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.title = "Outdoor Environment"
+    entry.runtime_data = OutdoorEnvironmentData(
+        coordinator_aq=aq,
+        coordinator_weather=weather,
+    )
+    entry.data = {}
+    entry.options = {}
+
+    sensor = sensor_cls(entry)
+    sensor.async_on_remove = MagicMock()
+    await sensor.async_added_to_hass()
+
+    assert aq.async_add_listener.call_count == expected_aq
+    assert weather.async_add_listener.call_count == expected_weather
 
 
 def test_irrigation_needed_true():


### PR DESCRIPTION
**Depends on #5 (`fix: apply updated solar panel options`). Please merge #5 before this one.** This branch is already rebased on top of it, so the merge itself will be clean — just merge #5 first.

Skip startup and periodic polling of an API when nothing enabled actually consumes it, and gate each derived sensor on the API it reads (`demand_aq` / `demand_weather`) instead of on entity-group flags.

- A single `get_api_demand()` helper in `const.py` computes `demand_aq` / `demand_weather` from the config groups; `__init__.py` uses it to skip the initial refresh and periodic polling for an unused API, and `sensor_derived.py` uses the same result to decide which derived sensors to create — one mapping, not two.
- Each derived sensor is gated on the API it actually reads, not on the group flag that happens to also enable an unrelated entity. `DominantPollutantSensor` gates on `demand_aq`; `LightningRiskSensor` and `IrrigationNeededSensor` gate on `demand_weather`. All three default to `True`, so a stock default install keeps every entity it has today — only a user who explicitly disables air quality or weather sees fewer entities, which is the intended behavior.
- `PollenTotalRiskSensor` reports `unknown` instead of a false `0` when the Pollen group is off or the install is outside the EU, since there's no pollen data to derive a risk from.
- `AirQualityCoordinator` and `WeatherCoordinator` take `config_entry=entry` directly in their constructors.

My use case is wanting only AQ values, without paying for Open-Meteo forecast-API hits nobody's using. Both API queries turn off independently, for symmetry, whichever group you disable.

This is a user-visible behavior change (fewer entities when you disable a group), so it's tagged `feat:` and targeted at 0.2.0, with a `CHANGELOG.md` entry under `Unreleased`.
