### PR TITLE
ci: run tests on Python 3.14

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,13 +24,13 @@ jobs:
           category: integration
 
   tests:
-    name: Tests (Python 3.13)
+    name: Tests (Python 3.14)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install -r requirements_test.txt
       - name: Run tests


### PR DESCRIPTION
The test job pinned Python 3.13, which silently capped the test environment.

`pytest-homeassistant-custom-component` requires Python >= 3.14 from 0.13.340 onward (verified on PyPI: 0.13.316 → `>=3.13`, 0.13.340 / 0.13.356 / 0.13.357 → `>=3.14`). With the interpreter pinned to 3.13, pip resolved back to 0.13.316 every time, which pins `homeassistant==2026.2.3`.

So every CI run so far — including the one on the 0.1.2 crash fix — has been testing against Home Assistant 2026.2.3. Nothing has ever been exercised against 2026.8.x in CI; the only confirmation on a current HA came from the reporter of #3 running it on their own install.

This bump is also the real prerequisite for the `CONCENTRATION_*` deprecation work, which was previously recorded as unblocked on the strength of the package being on PyPI.

**This PR exists to find out whether we pass.** A red run here is the useful outcome, not a failure of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)