### PR TITLE
feat: remove stale sensor entities from the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   could never hold a value. If you have disabled a whole group, some calculated
   sensors will no longer be created.
   ([@bexelbie](https://github.com/bexelbie))
+- **Entities the configuration no longer provides are deleted from the entity
+  registry.** Disabling a sensor group stopped its entities from being created,
+  but the registry kept the rows, so they stayed `unavailable` forever with no
+  way out except deleting each one by hand. They are now removed at startup,
+  which is what Home Assistant's own integrations do. **Deleting a registry row
+  also deletes that entity's history and long-term statistics, and that cannot
+  be undone**: re-enabling the group creates the entities again, empty. Only the
+  `sensor` domain is touched.
 
 ## [0.1.2] - 2026-08-19
 

--- a/custom_components/outdoor_environment/sensor.py
+++ b/custom_components/outdoor_environment/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -14,6 +15,7 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
+    Platform,
     UnitOfIrradiance,
     UnitOfLength,
     UnitOfPressure,
@@ -22,6 +24,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -53,6 +56,8 @@ from .const import (
 from .coordinator_aq import AirQualityCoordinator
 from .coordinator_weather import WeatherCoordinator
 from .sensor_derived import create_derived_sensors
+
+_LOGGER = logging.getLogger(__name__)
 
 _COORDINATOR_AQ = "aq"
 _COORDINATOR_WEATHER = "weather"
@@ -473,6 +478,36 @@ class GtiSensor(
 # Platform setup
 # ---------------------------------------------------------------------------
 
+def _async_remove_stale_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    entities: list[SensorEntity],
+) -> None:
+    """Drop registry entries for sensors this configuration no longer provides.
+
+    Disabling a sensor group stops the matching entities from being created, but
+    the registry keeps its rows, so they linger as `unavailable` forever. Anything
+    registered to this entry whose unique_id is not in the set we are about to add
+    is stale by definition.
+
+    Only the sensor domain is touched: other platforms clean up after themselves.
+    """
+    registry = er.async_get(hass)
+    expected = {entity.unique_id for entity in entities}
+
+    for registry_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if registry_entry.domain != Platform.SENSOR:
+            continue
+        if registry_entry.unique_id in expected:
+            continue
+        _LOGGER.debug(
+            "Removing stale entity %s (unique_id=%s): no longer provided by this configuration",
+            registry_entry.entity_id,
+            registry_entry.unique_id,
+        )
+        registry.async_remove(registry_entry.entity_id)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -545,4 +580,5 @@ async def async_setup_entry(
     # Group F — derived sensors
     entities += create_derived_sensors(entry, cfg, demand_aq, demand_weather)
 
+    _async_remove_stale_entities(hass, entry, entities)
     async_add_entities(entities)

--- a/custom_components/outdoor_environment/tests/test_sensor_platform.py
+++ b/custom_components/outdoor_environment/tests/test_sensor_platform.py
@@ -329,6 +329,84 @@ async def test_boolean_sensors_carry_no_state_class(
     assert state.attributes.get("state_class") is None
 
 
+async def test_stale_sensor_entities_are_removed_from_the_registry(
+    hass, mock_config_entry, aq_response, wx_response
+):
+    """A sensor this configuration no longer provides must not linger as unavailable."""
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    stale = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{mock_config_entry.entry_id}_retired_sensor",
+        config_entry=mock_config_entry,
+    )
+
+    with _patched_apis(_floats(aq_response["current"]), _floats(wx_response["current"])):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert registry.async_get(stale.entity_id) is None
+    assert _entity_ids(hass, mock_config_entry), "cleanup must not empty the registry"
+
+
+async def test_cleanup_leaves_other_platforms_alone(
+    hass, mock_config_entry, aq_response, wx_response
+):
+    """Only the sensor domain is ours to prune — 0.3.0 adds binary_sensor entities."""
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    other_domain = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{mock_config_entry.entry_id}_frost_risk",
+        config_entry=mock_config_entry,
+    )
+
+    with _patched_apis(_floats(aq_response["current"]), _floats(wx_response["current"])):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert registry.async_get(other_domain.entity_id) is not None
+
+
+async def test_disabling_a_group_prunes_only_that_group(
+    hass, mock_config_entry, aq_response, wx_response
+):
+    """Turning a group off removes its entities and leaves the others in place."""
+    mock_config_entry.add_to_hass(hass)
+
+    def _has(unique_id: str) -> bool:
+        return any(
+            entity.config_entry_id == mock_config_entry.entry_id
+            and entity.unique_id == unique_id
+            for entity in er.async_get(hass).entities.values()
+        )
+
+    weather_uid = f"{mock_config_entry.entry_id}_temperature_2m"
+    aq_uid = f"{mock_config_entry.entry_id}_european_aqi"
+
+    with _patched_apis(_floats(aq_response["current"]), _floats(wx_response["current"])):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert _has(weather_uid)
+        assert _has(aq_uid)
+
+        hass.config_entries.async_update_entry(
+            mock_config_entry,
+            options={
+                "enable_weather": False,
+                "enable_solar": False,
+                "enable_group_d_agro": False,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert not _has(weather_uid)
+    assert _has(aq_uid)
+
+
 def test_every_derived_sensor_is_covered_by_this_module():
     """Guard: a new derived sensor must not silently escape platform testing."""
     from custom_components.outdoor_environment import sensor_derived


### PR DESCRIPTION
Disabling a sensor group stops its entities from being created, but the entity
registry keeps the rows. They linger as `unavailable` forever, and the only way
out is deleting each one by hand.

After the entity list is built, `async_setup_entry` drops every registry row
belonging to this config entry whose `unique_id` is not in it.

**Why the expected set comes from the entities themselves.** It would be easy to
recompute which sensors "should" exist from the enabled groups, but that is a
second copy of the group logic, and it would drift from the real one the first
time a group is added. The list we are about to pass to `async_add_entities` is
the answer by construction.

**Why only the `sensor` domain.** `binary_sensor` arrives in 0.3.0 and owns its
own rows; pruning them from here would delete entities another platform is about
to add. That migration is also the reason this routine is worth having in place
first — it is what will retire the two `sensor` rows the platform move leaves
behind, and it gets to run in the wild for a release before that happens.

**Why not `async_migrate_entry`.** That hook is for config entry schema versions,
not for the entity lifecycle.

## The cost, accepted deliberately

Removing a registry row also removes that entity's history and long-term
statistics, and there is no undo. Someone who disables a group to see what
happens and changes their mind an hour later does not get their data back.

The alternative — leaving the rows as `unavailable` — is worse in the common
case and is not what core integrations do, so the cleanup stays and the
changelog says plainly what it costs.

## Verification

96 tests green locally, including 78 lines of new platform-level tests in
`test_sensor_platform.py` — the layer where Home Assistant actually validates
entities, rather than `native_value` one level below.

Local runs are on Python 3.13 / HA 2026.2.3, which is why this is a pull request
rather than a push to `main`: CI is the only place it meets Python 3.14 /
HA 2026.8.3, and this is the commit that touches the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)