### PR TITLE
ci: move off actions still targeting Node.js 20

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,14 +11,14 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: home-assistant/actions/hassfest@master
 
   hacs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: hacs/action@main
         with:
           category: integration
@@ -27,8 +27,8 @@ jobs:
     name: Tests (Python 3.14)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
       - name: Install dependencies


### PR DESCRIPTION
Every job in the v0.2.0 run logged the same warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-python@v5`.

Forcing works today, so this is not urgent — but it stops working when the runners drop the shim, and CI is the only place this integration is tested against the Home Assistant version users actually run.

Both actions go to their current major, `v7`, which targets Node.js 24 natively. Neither step passes an input that changed across those majors, so this is version numbers and nothing else. The green run on this PR is the whole verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)